### PR TITLE
3.1 a metrics implementation

### DIFF
--- a/packages/api/api/router/metrics.py
+++ b/packages/api/api/router/metrics.py
@@ -3,7 +3,7 @@ from metrics.models import (
     MetricsInfo,
     MetricValues,
 )
-from metrics.metrics import MetricsException
+from metrics.metrics import MetricsComputationException
 from metrics.metrics import calculate_metrics as _calculate_metrics
 from fastapi import FastAPI, HTTPException
 
@@ -54,5 +54,5 @@ async def calculate_metrics(info: CalculateRequest) -> MetricValues:
     """
     try:
         return _calculate_metrics(info)
-    except MetricsException as e:
+    except MetricsComputationException as e:
         raise HTTPException(status_code=500, detail=e.detail)

--- a/packages/api/tests/integration/test_dataset_fetching_intgr.py
+++ b/packages/api/tests/integration/test_dataset_fetching_intgr.py
@@ -10,14 +10,14 @@ from fastapi.testclient import TestClient
 
 app_client = TestClient(server_app)
 
-valid_dataset_url = "http://127.0.0.1:2222/fetch-datapoints"
-invalid_format_url = "http://127.0.0.1:2222/invalid-data-format"
-not_found_url = "http://127.0.0.1:2222/not-found-url"
+valid_dataset_url = "http://127.0.0.1:2224/fetch-datapoints"
+invalid_format_url = "http://127.0.0.1:2224/invalid-data-format"
+not_found_url = "http://127.0.0.1:2224/not-found-url"
 
 
 @pytest.fixture(scope="module")
 def run_servers():
-    data_config = uvicorn.Config(app=client_mock, host="127.0.0.1", port=2222)
+    data_config = uvicorn.Config(app=client_mock, host="127.0.0.1", port=2224)
     data_server = uvicorn.Server(data_config)
 
     def start_server(server):

--- a/packages/metrics/metrics/error_handling.md
+++ b/packages/metrics/metrics/error_handling.md
@@ -1,0 +1,6 @@
+# TODO: Explain error passing system within metrics package.
+
+Things to consider:
+
+- Raising DataProvisionExceptions (interal, server-side errors in most cases)
+- Returning Union of Metrics and Results for any metric

--- a/packages/metrics/metrics/exceptions.py
+++ b/packages/metrics/metrics/exceptions.py
@@ -16,7 +16,6 @@ class _MetricsPackageException(Exception, ABC):
         self.status_code = status_code
         super().__init__(self.detail)
 
-
     @abstractmethod
     def to_pydantic_model(self) -> dict:
         return {

--- a/packages/metrics/metrics/exceptions.py
+++ b/packages/metrics/metrics/exceptions.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from warnings import warn
 
 
-class __MetricsPackageException(Exception, ABC):
+class _MetricsPackageException(Exception, ABC):
     """
     __MetricsPackageException is the base exception class for the metrics package
         - it extends Exception as an abstract class and requires a detail field (not empty)
@@ -17,7 +17,16 @@ class __MetricsPackageException(Exception, ABC):
         super().__init__(self.detail)
 
 
-class MetricsException(__MetricsPackageException):
+    @abstractmethod
+    def to_pydantic_model(self) -> dict:
+        return {
+            "detail": self.detail,
+            "status_code": self.status_code,
+            "exception_type": self.__class__.__name__
+        }
+
+
+class MetricsComputationException(_MetricsPackageException):
     """
     Class for all metric-related exceptions (as a result of metric calculation).
 
@@ -35,7 +44,7 @@ class MetricsException(__MetricsPackageException):
         super().__init__(err_msg, status_code)
 
 
-class DataInconstencyException(__MetricsPackageException):
+class DataInconsistencyException(_MetricsPackageException):
     """
     Class representing invalid inputs for metric calculations - specifically regarding
     .e.g. inconsistent number of datapoints or other data inconstency issues
@@ -54,7 +63,7 @@ class DataInconstencyException(__MetricsPackageException):
         super().__init__(err_msg, status_code)
 
 
-class ModelQueryException(__MetricsPackageException):
+class ModelQueryException(_MetricsPackageException):
     """
     Class for all model query-related exceptions (as a result of querying the model during
     metric calculations or otherwise).
@@ -72,7 +81,7 @@ class ModelQueryException(__MetricsPackageException):
         super().__init__(err_msg, status_code)
 
 
-class InsufficientDataProvisionException(__MetricsPackageException):
+class DataProvisionException(_MetricsPackageException):
     """
     Class representing insufficient data provision for metric calculations - this occurs when
     the user's choice of metrics require certain extra data to be provided. If the conditions

--- a/packages/metrics/metrics/metrics.py
+++ b/packages/metrics/metrics/metrics.py
@@ -734,7 +734,7 @@ def check_all_required_fields_present(metrics: set[str], info: CalculateRequest)
         if metric not in metric_to_fn_and_requirements:
             metrics_to_exceptions[metric] = MetricsComputationException(
                 metric,
-                detail=f"Metric should be supported, but is not mapped to a computation. (Internal Error)"
+                detail="Metric should be supported, but is not mapped to a computation. (Internal Error)"
             )
         else:
             missing_fields = []
@@ -744,7 +744,7 @@ def check_all_required_fields_present(metrics: set[str], info: CalculateRequest)
             if missing_fields:
                 metrics_to_exceptions[metric] = DataProvisionException(
                     detail=f"The following missing fields are required to calculate metric {metric}:\n"
-                            f"{missing_fields}"
+                           f"{missing_fields}"
                 )
     return metrics_to_exceptions
 
@@ -758,21 +758,22 @@ def check_metrics_are_supported_for_task(info: CalculateRequest):
         raise DataProvisionException(
             detail=f"Task {info.task_name} is not supported. Please choose a valid task."
         )
-    
+
     invalid_metrics = set(info.metrics) - task_type_to_metric[info.task_name]
     metrics_to_exceptions = {}
     for metric in invalid_metrics:
-            metrics_to_exceptions[metric] = MetricsComputationException(
-                metric,
-                detail=(
-                    f"Metric {metric} is not supported for {info.task_name} tasks."
-                    " Please only choose valid metrics for the task type."
-                    "\nSupported metrics for this task type are:\n"
-                    f" {task_type_to_metric[info.task_name]}"
-                ),
-                status_code=400
-            )
+        metrics_to_exceptions[metric] = MetricsComputationException(
+            metric,
+            detail=(
+                f"Metric {metric} is not supported for {info.task_name} tasks."
+                " Please only choose valid metrics for the task type."
+                "\nSupported metrics for this task type are:\n"
+                f" {task_type_to_metric[info.task_name]}"
+            ),
+            status_code=400
+        )
     return metrics_to_exceptions
+
 
 def calculate_metrics(info: CalculateRequest) -> MetricValues:
     """

--- a/packages/metrics/metrics/models.py
+++ b/packages/metrics/metrics/models.py
@@ -1,5 +1,5 @@
-from pydantic import BaseModel, field_validator, HttpUrl, field_serializer, Field
-from typing import Optional, Any, Union, List
+from pydantic import BaseModel, field_validator, HttpUrl, Field
+from typing import Optional, Any, Union
 from common.utils import nested_list_to_np
 from metrics.exceptions import _MetricsPackageException
 

--- a/packages/metrics/tests/test_metric_utils.py
+++ b/packages/metrics/tests/test_metric_utils.py
@@ -124,7 +124,7 @@ def test_query_model_success(mock_post):
     assert response.confidence_scores == confidence_scores
 
 
-def test_query_model_http_error(mock_post):
+def test_query_model_returns_http_error(mock_post):
     """
     Assert a ModelQueryException is raised when the model API returns an HTTP error.
     """

--- a/packages/metrics/tests/test_metrics.py
+++ b/packages/metrics/tests/test_metrics.py
@@ -17,7 +17,6 @@ from metrics.metrics import (
 )
 from metrics.exceptions import (
     MetricsComputationException,
-    DataProvisionException,
     DataInconsistencyException
 )
 from metrics.models import CalculateRequest, MetricsPackageExceptionModel
@@ -360,8 +359,8 @@ def test_calculate_metrics_with_missing_information_returns_insufficient_data_er
     assert results.metric_values == {
         "accuracy": MetricsPackageExceptionModel(
             detail="Insufficient data provided to calculate user metrics: "
-                "The following missing fields are required to calculate metric "
-                "accuracy:\n['true_labels', 'predicted_labels']",
+                   "The following missing fields are required to calculate metric "
+                   "accuracy:\n['true_labels', 'predicted_labels']",
             status_code=400,
             exception_type="DataProvisionException",
         )


### PR DESCRIPTION
- Refactor Exceptions to be returned rather than raised for the workers to pass to the frontend for displaying.
- This prevents one metric failure from stopping all other metrics being calculated
- Once exception to this is the `DataInconsistencyException` which does not relate to any particular metric and should be handled by the worker as a Data related error where (possibly) the model is implemented incorrectly  