### PR TITLE
Dealing with connection reset error on prod

### DIFF
--- a/packages/api/api/router/api.py
+++ b/packages/api/api/router/api.py
@@ -5,6 +5,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import JSONResponse
 from pika.adapters.blocking_connection import BlockingChannel
 from common.rabbitmq.constants import JOB_QUEUE
+from common.rabbitmq.connect import publish_to_queue
 from metrics.metrics import task_type_to_metric
 from metrics.models import MetricsInfo
 
@@ -90,8 +91,8 @@ def dispatch_job(
         batch_size=batch_size,
         metrics=metrics,
     )
-    message = job.json()
-    channel.basic_publish(
-        exchange="", routing_key=JOB_QUEUE, body=message, mandatory=True
-    )
+    message = job.model_dump_json()
+
+    _ = publish_to_queue(channel, JOB_QUEUE, message)
+
     return job_id

--- a/packages/common/tests/test_connect.py
+++ b/packages/common/tests/test_connect.py
@@ -2,8 +2,9 @@ import redis
 import pytest
 from unittest.mock import patch, MagicMock
 import pika
+import pika.exceptions
 from pika.adapters.blocking_connection import BlockingChannel
-from common.rabbitmq.connect import connect_to_rabbitmq, init_queues
+from common.rabbitmq.connect import connect_to_rabbitmq, init_queues, publish_to_queue
 from common.redis.connect import connect_to_redis
 
 # Tests created with copilot
@@ -69,6 +70,7 @@ def test_connect_to_redis_success(mock_sleep, mock_redis_from_url):
 
 @patch("common.redis.connect.redis.Redis.from_url", side_effect=redis.ConnectionError)
 @patch("common.redis.connect.sleep", return_value=None)
+@pytest.mark.asyncio
 async def test_connect_to_redis_retry(mock_sleep, mock_redis_from_url):
     with pytest.raises(Exception):
         connect_to_redis(url="redis://localhost", retries=3)
@@ -83,3 +85,41 @@ def test_connect_to_redis_exhaust_retries(mock_sleep, mock_redis_from_url):
         connect_to_redis(url="redis://localhost", retries=10)
     assert mock_redis_from_url.call_count == 10
     assert mock_sleep.call_count == 10
+
+
+@patch("common.rabbitmq.connect.connect_to_rabbitmq")
+def test_publish_to_channel_success(mock_connect_to_rabbitmq):
+    """Test successful message publishing"""
+    mock_channel = MagicMock(spec=BlockingChannel)
+
+    with patch.object(mock_channel, "basic_publish") as mock_basic_publish:
+        publish_to_queue(mock_channel, "test_queue", "test_message")
+
+    mock_basic_publish.assert_called_once_with(
+        exchange="", routing_key="test_queue", body="test_message"
+    )
+
+
+@patch("common.rabbitmq.connect.connect_to_rabbitmq")
+def test_publish_to_channel_reconnect(mock_connect_to_rabbitmq):
+    """Test publishing when the first attempt fails and requires reconnection"""
+    mock_channel = MagicMock(spec=BlockingChannel)
+
+    mock_new_channel = MagicMock(spec=BlockingChannel)
+    mock_connection = MagicMock()
+    mock_connection.channel.return_value = mock_new_channel
+    mock_connect_to_rabbitmq.return_value = mock_connection
+
+    with patch.object(mock_channel, "basic_publish", side_effect=pika.exceptions.AMQPConnectionError) \
+         as mock_basic_publish, \
+         patch.object(mock_new_channel, "basic_publish") as mock_new_basic_publish:
+        publish_to_queue(mock_channel, "test_queue", "test_message")
+
+        # First attempt failed, so it should retry
+        mock_basic_publish.assert_called_once_with(
+            exchange="", routing_key="test_queue", body="test_message"
+        )
+        mock_connect_to_rabbitmq.assert_called_once()
+        mock_new_basic_publish.assert_called_once_with(
+            exchange="", routing_key="test_queue", body="test_message"
+        )

--- a/packages/dispatcher/dispatcher/dispatcher.py
+++ b/packages/dispatcher/dispatcher/dispatcher.py
@@ -5,6 +5,7 @@ import uuid
 
 from common.models.pipeline import Batch, JobStatusMessage, JobStatus, PipelineJob
 from common.rabbitmq.constants import BATCH_QUEUE, JOB_QUEUE, STATUS_QUEUE
+from common.rabbitmq.connect import publish_to_queue
 from dispatcher.models import RunningJob
 from dispatcher.utils import redis_key
 from worker.worker import WorkerException
@@ -84,11 +85,7 @@ class Dispatcher:
         """Dispatch a single batch for the given job id"""
         try:
             logger.info(f"Dispatching batch for job {job_id}")
-            self._channel.basic_publish(
-                exchange="",
-                routing_key=BATCH_QUEUE,
-                body=job_data.model_dump_json(),
-            )
+            self._channel = publish_to_queue(self._channel, BATCH_QUEUE, job_data.model_dump_json())
             logger.info(f"Batch dispatched for job {job_id}")
         except Exception as e:
             self.propogate_error(job_id, e)


### PR DESCRIPTION
Added helper function - instead of basic_publish directly uses publish_to_queue.
If there is a connection issue, spin up a new connection and reinitialise queues.
Added robustness for message passing - should hopefully fix the issue in prod.